### PR TITLE
Deal with salted passwords in Redmine 4

### DIFF
--- a/src/api/Models/User.php
+++ b/src/api/Models/User.php
@@ -14,6 +14,10 @@ class User extends \ActiveRecord\Model
 
     public function passwordCheck($plainPassword) {
         $hashedPassword = sha1($plainPassword);
+        $salt = $this->salt;
+        if (isset($salt)) {
+            $hashedPassword = sha1($salt . $hashedPassword);
+        }
         return $hashedPassword == $this->hashed_password;
     }
 


### PR DESCRIPTION
Redmine 4 adds a salt to the SHA1-hashed passwords. If the "salt" field of the user record is present, the hashed password is calculated by SHA1(salt + SHA1(cleartext)) where + means string concatenation.

Note: I have verified (by manually reproducing the process) that this produces correct results on the test LanguageDepot servers. I have not yet succeeded in testing this via a Language Forge API request, because the API request is returning a 500 server error at some point after the `passwordCheck` step, and I haven't yet tracked down the cause of that 500 error.