### PR TITLE
Fix SQL query for Redmine 4

### DIFF
--- a/src/api/UserController.php
+++ b/src/api/UserController.php
@@ -43,8 +43,8 @@ class UserController
         }
 
         $projects = Project::find('all', array(
-            'joins' => array('members'),
-            'select' => 'projects.identifier,projects.name,members.user_id,members.role_id',
+            'joins' => ['members', 'LEFT JOIN member_roles ON member_roles.member_id = members.id'],
+            'select' => 'projects.identifier,projects.name,members.user_id,member_roles.role_id',
             'conditions' => $conditions
         ));
         $result = array();


### PR DESCRIPTION
Redmine 4 moved the role_id field out of the `members` table and into a `member_roles` table.

This has been tested against the Redmine 4 code currently deployed on the LD test server, and it works once the SQL changes in this PR have been made on the test server. (The version deployed on the test server isn't from the `master` branch of this repo, so I couldn't just copy the file over; instead, I made the same changes on the server as in this PR, and it worked).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languagedepot-php-api/9)
<!-- Reviewable:end -->
