### PR TITLE
Fix API endpoint for user list of projects

### DIFF
--- a/src/api/ApiControllerProvider.php
+++ b/src/api/ApiControllerProvider.php
@@ -22,8 +22,8 @@ class ApiControllerProvider implements ControllerProviderInterface
         $app['user.controller'] = $app->share(function() {
             return new UserController();
         });
-        $controllers->post('/users/{login}/projects', 'user.controller:getProjectsAccess');
-        $controllers->get('/users/exists/{username}', 'user.controller:usernameIsAvailable');
+        $controllers->post('/user/{login}/projects', 'user.controller:getProjectsAccess');
+        $controllers->get('/user/exists/{username}', 'user.controller:usernameIsAvailable');
         $controllers->post('/users', 'user.controller:create');
         $controllers->put('/users', 'user.controller:update');
         return $controllers;


### PR DESCRIPTION
The API endpoint that Language Forge calls is `/user/{login}/projects`, not `/users/{login}/projects`. This change was made in commit 1c60c2214a750997e30435ec6ad0ae5379e41a83. This commit partially reverts that one, but leaves the `/users` API endpoint in place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-languagedepot-php-api/10)
<!-- Reviewable:end -->
